### PR TITLE
Fix caption serialization when print-length or print-level is non-nil

### DIFF
--- a/elfeed-tube.el
+++ b/elfeed-tube.el
@@ -422,7 +422,16 @@ buffer."
                                     ((capstr (elfeed-deref
                                               (elfeed-meta entry :caps))))
                                   (condition-case nil
-                                      (read capstr)
+                                      (let ((parsed (read capstr)))
+                                        (if (cl-some (lambda (el) (not (consp el)))
+                                                     (cddr parsed))
+                                            (progn ;guard against corrupted DB data (#51)
+                                              (elfeed-tube-log
+                                               'warn
+                                               "[Show][Captions] Corrupt data in DB (truncated by print-length), discarding")
+                                              (setf (elfeed-meta entry :caps) nil)
+                                              nil)
+                                          parsed))
                                     (error
                                      (elfeed-tube-log
                                       'error "[Show][Captions] DB parse error: %S"

--- a/elfeed-tube.el
+++ b/elfeed-tube.el
@@ -305,7 +305,9 @@ paragraphs or sections. It must be a positive integer."
       (elfeed-tube--with-db elfeed-tube--captions-db-dir
         (setf (elfeed-meta entry :caps)
               (when-let ((caption (elfeed-tube-item-caps data-item)))
-                (elfeed-ref (prin1-to-string caption))))))
+                (elfeed-ref (let ((print-length nil)
+                                  (print-level nil))
+                              (prin1-to-string caption)))))))
     (elfeed-tube-log 'info "[DB][Wrote to DB][video:%s]"
                      (elfeed-tube--truncate (elfeed-entry-title entry)))
     t))


### PR DESCRIPTION
## Summary

- `elfeed-tube--write-db` serializes captions with `prin1-to-string`, which respects the global `print-length` and `print-level` variables. When either is non-nil, the output is truncated with `...`, corrupting the saved data.
- When the truncated string is later `read` back in `elfeed-tube-show`, the `...` becomes a literal symbol, causing `wrong-type-argument` errors in `elfeed-tube--insert-captions`.

## Fix

Let-bind `print-length` and `print-level` to nil around the `prin1-to-string` call so the full caption data is always written regardless of the user's print settings.

## Reproducer

1. Set `print-length` and/or `print-level` to a non-nil value (e.g. 10).
2. Visit a YouTube entry in elfeed whose captions have more elements than `print-length`.
3. Captions are saved truncated. On next visit, `elfeed-tube--insert-captions` errors with `(wrong-type-argument listp \...)` or `(wrong-type-argument stringp nil)`.