### PR TITLE
Fix caption language matching for non-English videos

### DIFF
--- a/elfeed-tube-utils.el
+++ b/elfeed-tube-utils.el
@@ -117,13 +117,12 @@
 
 (defsubst elfeed-tube--match-captions-langs (lang el)
   "Find caption track matching LANG in plist EL."
-  (and (or (string-match-p
-            lang
-            (plist-get el :languageCode))
-           (string-match-p
-            lang
-            (thread-first (plist-get el :name)
-                          (plist-get :simpleText))))
+  (and (or (and-let* ((code (plist-get el :languageCode)))
+             (string-match-p lang code))
+           (and-let* ((name (or (map-nested-elt el '(:name :runs 0 :text))
+                                (thread-first (plist-get el :name)
+                                              (plist-get :simpleText)))))
+             (string-match-p lang name)))
        el))
 
 (defsubst elfeed-tube--truncate (str)

--- a/elfeed-tube.el
+++ b/elfeed-tube.el
@@ -832,6 +832,7 @@ This does the following:
       (when (and elfeed-tube-captions-sblock-p sblock)
         (setq parsed-caps (elfeed-tube--sblock-captions sblock parsed-caps)))
       (when (and elfeed-tube-captions-puntcuate-p
+                 language
                  (string-match-p "auto-generated" language))
         (elfeed-tube--npreprocess-captions parsed-caps))
       parsed-caps)))


### PR DESCRIPTION
## Summary

- `elfeed-tube--match-captions-langs` crashes with `(wrong-type-argument stringp nil)` when iterating caption tracks whose `:languageCode` does not match the user's preferred language.
- The fallthrough branch calls `(string-match-p lang (plist-get (plist-get el :name) :simpleText))`, but the YouTube innertube ANDROID client returns caption names in the `:runs` format (`(:runs [(:text "English")])`) rather than `:simpleText`. The second argument to `string-match-p` is therefore nil.
- This affects any video with non-English caption tracks: when checking e.g. `"en"` against a track with `:languageCode "ko"`, the first `string-match-p` returns nil (no match), then the second receives nil from the absent `:simpleText` and errors.

## Fix

- Guard both `string-match-p` calls in `elfeed-tube--match-captions-langs` against nil arguments.
- Check the `:runs` name format in addition to the legacy `:simpleText`, consistent with how `elfeed-tube--youtube-fetch-captions-url` already extracts the language name.
- Guard against nil `language` in `elfeed-tube--youtube-fetch-captions`.

## Reproducer

1. Subscribe to a YouTube channel that publishes videos with non-English captions (e.g., a Korean or Japanese channel).
2. Open one of these entries in elfeed-show.
3. `elfeed-tube--match-captions-langs` errors with `(wrong-type-argument stringp nil)` when it reaches a caption track whose `:languageCode` doesn't match and whose `:name` uses the `:runs` format.