### PR TITLE
Guard against nil entry link in elfeed-tube--youtube-p

### DIFF
--- a/elfeed-tube-utils.el
+++ b/elfeed-tube-utils.el
@@ -64,8 +64,8 @@
 
 (defsubst elfeed-tube--youtube-p (entry)
   "Check if ENTRY is a Youtube video entry."
-  (string-match-p elfeed-tube-youtube-regexp
-                  (elfeed-entry-link entry)))
+  (and-let* ((link (elfeed-entry-link entry)))
+    (string-match-p elfeed-tube-youtube-regexp link)))
 
 (defsubst elfeed-tube--url-video-id (url)
   "Get YouTube video URL's video-id."


### PR DESCRIPTION
## Summary

`elfeed-tube--youtube-p` passes `(elfeed-entry-link entry)` directly to `string-match-p`, which signals `wrong-type-argument stringp nil` when the entry has no link. This can happen during background elfeed updates via `elfeed-new-entry-hook` when a feed contains entries without links.

The fix wraps the call in `when-let`, returning nil for entries without a link.

## Backtrace

```
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  signal(wrong-type-argument (stringp nil))
  #f(compiled-function () #<bytecode -0xc894b47080fd88b>)()
  #f(compiled-function (fetched-p) #<bytecode 0xcd3a80afad35f2b>)(#f(compiled-function () #<bytecode -0xc894b47080fd88b>))
  apply(#f(compiled-function (fetched-p) #<bytecode 0xcd3a80afad35f2b>) #f(compiled-function () #<bytecode -0xc894b47080fd88b>))
  timer-event-handler([t 27048 18433 27511 nil #f(compiled-function (fetched-p) #<bytecode 0xcd3a80afad35f2b>) (#f(compiled-function () #<bytecode -0xc894b47080fd88b>)) nil 0 nil])
```